### PR TITLE
First-pass trajectory-accepting gRPC schema for platform

### DIFF
--- a/schema.proto
+++ b/schema.proto
@@ -1,0 +1,151 @@
+syntax="proto3";
+import "google/protobuf/empty.proto";
+
+/**************************************************************************************************
+* Services
+**************************************************************************************************/
+
+service Platform {
+    // Represents the play platform.
+    // Served by the platform microcontroller via some kind of serial bus (TBD exactly how)
+
+    rpc GetState(google.protobuf.Empty) returns (PlatformState);
+
+    // Expected to be called quite regularly. Will return any errors thrown since the last invocation
+    // (i.e. if there's been a hardware fault). Will not block (so that it can get called again in a 
+    // busy loop based on the next cat detection update from OpenCV).
+    // 
+    // Note that if the platform doesn't get a new Trajectory in time it will probably stop
+    // at max deceleration to avoid dropping the mouse on a wall (???)
+    rpc SetTrajectory(Trajectory) returns (HardwareResult);
+    rpc GetRemainingTrajectory(google.protobuf.empty) returns (Trajectory); // TODO is this needed
+
+    // Specs of the platform
+    rpc GetSpecs(google.protobuf.Empty) returns (PlatformSpecs);
+
+    // TODO detect and represent mouse catches somehow (with like "am I carrying a mouse" as part of
+    // PlatformState and some way of the platform alerting the Pi when there's a catch)
+}
+
+service Personality {
+    // Representation of the personality of a particular mouse.
+    // 
+    // TODO is this a gRPC service? Or maybe just a Python script in a framework that generates
+    // gRPC calls directly to Platform objects
+
+    // Gets the name of the personality
+    rpc GetName(google.protobuf.Empty) returns (string);
+
+    // Requests a trajectory of upcoming motion from the Personality.
+    // 
+    // Note that trajectories can and should be overlapping; Personalities are encouraged to
+    // generate as much as a second forward in time just in case there are hiccups.
+    // (We'll see how much jitter we get from operating on Linux and communications delays,
+    // I'm guessing it'll be much less than a second, but there's no harm in going way forward
+    // in case there's some weird garbage collecting task hangup and we get a P99...)
+    // 
+    // Let's assume for the moment that it'll  be recomputed every, what, 0.1 seconds?
+    // TODO measure time to do cat detection with OpenCV and update this comment accordingly!
+    // 
+    rpc GetTrajectory(Map, MouseKinematicState, CatKinematicState) returns (Trajectory);
+}
+
+
+service CatDetector {
+    
+    // TODO probably worth service-ifying... but worth discussion too probably
+    rpc GetCatState(google.protobuf.Empty) returns (CatKinematicState);
+}
+
+
+
+
+/**************************************************************************************************
+* Messages
+**************************************************************************************************/
+
+message PlatformState {
+    MouseKinematicState mouse_kinematic_state = 1;
+    repeated MotorState motor_states = 2;
+    HardwareResult hardware_state = 3;  // SUCCESS means it's operating normally? is that cheesy? should it be a separate typed
+}
+
+message PlatformSpecs {
+    string model = 1;
+
+    // Active play area size in mm (note: doesn't include "inactive" play area outside the range of travel of the drive head)
+    float x_width_mm = 2;
+    float y_width_mm = 3;
+
+    // Max expected speed (based on motor specs) and acceleration. Used to bound incoming Trajectory requests.
+    // Note: These might have to be tweaked over product lifetime (by OTA I guess)
+    float max_speed_mmps = 1;  // millimeters/second
+    float max_acceleration_mmps2 = 2;  // max acceleration before we risk dropping the mouse, in millimeters/second^2
+}
+
+enum HardwareResult {
+    oneof result {  // TODO I think you have to check this with "is_set"? yuck. is there a more elegant way to express this
+        google.protobuf.Empty ok = 1;
+        HardwareError error = 2;
+    }
+}
+
+enum HardwareError {
+    FIRMWARE_ERROR = 1;
+    OVERCURRENT = 2;
+    OVERTEMPERATURE = 3;
+    OTHER_HARDWARE_FAULT = 4;  // TODO be specific about what's failed to allow repair/replacement
+}
+
+
+message MotorState {
+    optional float temperature_c = 1;
+    optional float current_a = 2;
+    optional float speed_mmps = 3; // millimeters/second of belt/cable
+}
+
+message MouseKinematicState {
+    Position position = 1;
+    Velocity velocity = 2;
+}
+
+message CatKinematicState {
+    Position position = 1;
+    Velocity velocity = 2;
+    // todo should we pass in Acceleration too? or let Personality implementers derive it if they need it
+}
+
+message Position {
+    float x_mm = 1;  // todo should we use all SI units (meter instead of millimeter)?
+    float y_mm = 2;  // for some reason I like mm but I'm not exactly sure why
+}
+
+message Velocity {
+    float x_dot_mmps = 1;  // millimeters/second
+    float y_dot_mmps = 2;  // millimeters/second
+}
+
+message Trajectory {
+    // To ensure smoothness of travel, personalities are encouraged to generate motions like curves
+    // as a series of small line segments that can be passed to the platform microcontroller together.
+
+    // Segments MUST be contiguous (ie segments[i-1].end == segments[i].start) or else we risk UB
+    repeated TrajectorySegment segments = 1;
+}
+
+message TrajectorySegment {
+    // An individual line segment within a Trajectory. Could plausibly be up to a meter for long runs
+    // or as short as single-digit mms on a curve (no harm in going fine-grained, the MCU can handle it)
+
+    // Start and end position
+    Position start = 1;
+    Position end = 2;
+
+    // Target speed on the trajectory in millimeters/second. Bounded by the maximum speed in the PlatformSpecs.
+    float speed_mmps = 3;
+    
+    // If the previous segment was a different speed, a target acceleration to use in changing from 
+    // the previous to the current speed. Will be bounded by the maximum acceleration in the PlatformSpecs.
+    // Set it low to get gradual acceleration over long straightaways (very mouselike)
+    float acceleration_mmps2 = 4;
+}


### PR DESCRIPTION
Here's a draft Protobuf schema for the platform microcontroller to serve into the Pi over gRPC. I'm open to other forms of inter-process communication if you'd prefer; I prefer to use Protobuf schemas to define the microcontroller interface and I do like gRPC.

The Trajectory object is defined because of some napkin math I did while working on the Software Design (https://docs.google.com/presentation/d/1i3XmMXIh98azn1EcekaH2YSO_yUDtzeTudp8wO8jqLw/edit#slide=id.p) that showed that to represent smooth curves in line segments we'll need some pretty fast segment-to-segment update rate. We could also accept curves/splines on the microcontroller but that gets into a whole territory that I don't know stuff about. 

Happy to accept feedback on everything in here!