### PR TITLE
Refactor "Node" to "Tile", add Path object

### DIFF
--- a/pi_controller/pi_controller/constants.py
+++ b/pi_controller/pi_controller/constants.py
@@ -27,8 +27,8 @@ MOUSE_HOUSE_ENTRANCE = 3
 
 # type wrapper for positions on the grid. 
 # TODO syntactic sugar for element-wise add/subtract??
-Node = Tuple[int, int] 
-Path = List[Node]
+Tile = Tuple[int, int] 
+Path = List[Tile]
 
 @dataclass
 class Point:  # A physical location on the board, measured in millimeters.

--- a/pi_controller/pi_controller/map_display.py
+++ b/pi_controller/pi_controller/map_display.py
@@ -117,7 +117,7 @@ class Game:
             cat_location=self.cat_location, 
             path=self.path, 
             cat_closeness_threshhold=1, 
-            check_upcoming_nodes=4,
+            check_upcoming_tiles=4,
             minimum_path_len=self.minimum_path_len
         )
         if new_path:

--- a/pi_controller/pi_controller/mice.py
+++ b/pi_controller/pi_controller/mice.py
@@ -8,14 +8,14 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from .motion.gcodes import GCode, LinearMove, UseAbsoluteCoordinates, UseRelativeCoordinates
-from .custommap import MapConfig, to_coordinates, Node
+from .custommap import MapConfig, to_coordinates, Tile
 from .motion import MotionCommand
 
 class MouseHouse:
     """
     """
     def __init__(self,
-                 map_coords: Node,  # (X, Y) position of the mouse house entrance, in map coordinates (position on the 50 mm grid)
+                 map_coords: Tile,  # (X, Y) position of the mouse house entrance, in map coordinates (position on the 50 mm grid)
                  occupied: Optional[bool] = None,
                  ) -> None:
         

--- a/pi_controller/pi_controller/motion/commands.py
+++ b/pi_controller/pi_controller/motion/commands.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import List, Tuple
 
 from .gcodes import GCode, UseAbsoluteCoordinates, UseRelativeCoordinates, LinearMove, ArcMove
-from ..constants import Path, Node, MapConfig
+from ..constants import Path, Tile, MapConfig
 from ..custommap import to_coordinates
 
 
@@ -47,7 +47,7 @@ class MotionCommand(metaclass=ABCMeta):
 class DirectMove(MotionCommand):
     ""
     
-    def __init__(self, destination: Node, speed_mm_s: float, map_config: MapConfig):
+    def __init__(self, destination: Tile, speed_mm_s: float, map_config: MapConfig):
         super().__init__()
         self.destination = destination
         self.speed_mm_s = speed_mm_s
@@ -136,7 +136,7 @@ class SimpleSquigglePath(MotionCommand):
         and goes to an adjacent neighbor (up, down, left, right).
         """
         super().__init__()
-        self.map_path = map_path  # List[Node]
+        self.map_path = map_path
         self.map_config = map_config
         self.speed_mm_s = speed_mm_s
 
@@ -233,7 +233,7 @@ class SimpleSquigglePath(MotionCommand):
         return gcodes
 
     @staticmethod
-    def _segment_direction(start: Node, end: Node) -> MapVector:
+    def _segment_direction(start: Tile, end: Tile) -> MapVector:
         dir = (end[0] - start[0], end[1] - start[1])
         assert abs(dir[0] + dir[1]) == 1, "I only know how to handle 1-length steps (up, left, right, or down)! Sorry!"
         return dir
@@ -264,7 +264,7 @@ class SimpleSquigglePath(MotionCommand):
 
         return i,j
 
-    def _full_arc(self, start: Node, end: Node, clockwise: bool) -> ArcMove:
+    def _full_arc(self, start: Tile, end: Tile, clockwise: bool) -> ArcMove:
         dir_vec = self._segment_direction(start, end)
 
         i, j = self._arc_center_offsets(direction=dir_vec, clockwise=clockwise)
@@ -278,7 +278,7 @@ class SimpleSquigglePath(MotionCommand):
             speed_mm_s=self.speed_mm_s
         )
     
-    def _two_half_arcs(self, start: Node, end: Node, first_arc_clockwise: bool) -> Tuple[ArcMove, ArcMove]:
+    def _two_half_arcs(self, start: Tile, end: Tile, first_arc_clockwise: bool) -> Tuple[ArcMove, ArcMove]:
         """
         Construct a segment which is two half-sized arcs. This segment starts and end with the same curl --
         if the last arc was clockwise, we'll do a small counterclockwise arc and then another clockwise

--- a/pi_controller/pi_controller/motion/moonraker.py
+++ b/pi_controller/pi_controller/motion/moonraker.py
@@ -9,6 +9,7 @@ import websockets
 import json
 import threading
 import time
+import copy
 
 import websockets.sync
 import websockets.sync.client
@@ -78,10 +79,12 @@ class MoonrakerSocket(MotionDriver):
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~ MotionDriver API ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     def enqueue_motion(self, motion: MotionCommand):
-        return super().enqueue_motion(motion)
+        with self._state_lock:
+            self._gcodes_queued.extend(motion.to_g_code())
 
     def get_current_position(self) -> Point:
-        return super().get_current_position()
+        with self._state_lock:
+            return copy.copy(self._current_location)  # TODO do I actually need to do this copy?
     
     def clear_queue(self):
         return super().clear_queue()

--- a/pi_controller/pi_controller/path.py
+++ b/pi_controller/pi_controller/path.py
@@ -1,0 +1,170 @@
+# path.py
+# 
+# A class for representing paths of motion along the play wall.
+# This serves as a central hinge point for translating mapping
+# into physical motion and back.
+
+from typing import List, Union, Optional
+import threading
+import copy
+from .constants import Tile
+
+
+class Path:
+    """
+    A representation of the path for the mouse to follow.
+
+    TODO what happens when we switch mice? Do we instantiate a new path 
+    or update the old one? I'm assuming we'll have one fixed Path which is
+    kind of the "path for the toolhead" rather than the path for any individual
+    mouse, and it will just happen to include stops to pick up and drop off
+    mice along the way. I think that's simpler than trying to maintain separate
+    state per mouse and swap back and forth. But let's discuss 🙏
+
+    This class serves as an interface between path planning and hardware, and
+    so it takes on responsibility for thread safety.
+    """
+
+    def __init__(self,
+                 tiles: Optional[List[Tile]] = None
+                 ):
+        """
+        """
+        self._lock = threading.Lock()
+        # List of tiles that the path goes through, in order
+        self._tiles = tiles or []  # n.b. you can't say `tiles: Optional... = []` or else Weird Shit Happens
+        # Segment of the Path that we've submitted to Klipper already (see commit_...() below)
+        self._committed_destination: Optional[Tile] = None  
+
+    def advance(self, current_tile: Tile):
+        """
+        Advance along the path to the current position -- that is, 
+        drop every Tile along the path that comes before the tile that
+        we're currently on.
+
+        Note that this method leaves current_tile in the Path object. 
+        For example:
+
+        ```
+        >>> path = Path([(0, 1), (1, 1), (1, 2), (2, 2)])
+        >>> path.advance((1, 2))
+        >>> path
+        Path([(1, 2), (2, 2)])
+        ```
+
+        I think this should work even for paths that cross themselves. Not that
+        we're likely to encounter that? Idk why I'm so concerned about this edge case...
+
+        Anyway this will be called by the motion platform to report where
+        the stage is.
+
+        Raises IndexError if the tile passed is not present in the path.
+        """
+        try:
+            with self._lock:    
+                tile_index = self._tiles.index(current_tile)
+                self._tiles = self._tiles[tile_index:]  # leaves current_tile in the list
+        except ValueError:
+            raise IndexError(f"Tile {current_tile} is not in path {self}!")
+
+    def commit_to_movement(self, target_tile: Tile):
+        """
+        Call me when we submit motion to Klipper to limits the amount that other
+        clients can truncate off the path.
+        
+        Raises IndexError if target_tile
+        """
+        with self._lock:
+            if not target_tile in self._tiles:
+                raise IndexError(f"Tile {target_tile} is not in path {self}!")
+            self._committed_destination = target_tile
+        
+
+    def extend(self, new_segment: 'Path'):            
+        """
+        Extend with another path segment.
+        """
+        with self._lock:
+            self._tiles.extend(new_segment._tiles)
+
+    def clear(self) -> Tile:
+        """
+        Attempt to drop as much of the upcoming path as we can.
+
+        Return the last Tile that we are committed to moving to.
+
+        If we haven't committed to any movement, drops all but the current
+        tile and returns that tile.
+        """
+        return self.truncate_at(self[0])  # attempt to truncate at the starting position
+
+
+    def truncate_at(self, end_tile: Tile) -> Tile:
+        """
+        Attempt to drop all Path beyond the indicated tile.
+
+        Return either the requested Tile or the last Tile that we're
+        committed to moving to, whichever is farther along the path.
+        """
+        if self._tiles:  # if self._tiles is still None then this should have no effect
+            with self._lock:
+                # We'll end either where we've committed to end or where we're 
+                # trying to end, whichever is farther out (that's correct yea??)
+
+                if end_tile not in self._tiles:
+                    raise IndexError(f"Tile {end_tile} is not in path {self}!")
+                
+                # If we've committed to a destination, then we might only be able 
+                # to truncate that far back
+                if self._committed_destination:
+                    truncate_end = max(
+                        self._tiles.index(self._committed_destination),
+                        self._tiles.index(end_tile)
+                    )
+                else:
+                    truncate_end_index = self._tiles.index(end_tile)
+                    
+                self._tiles = self._tiles[:truncate_end_index + 1]  # keep the end_tile in the list
+                
+                return self._tiles[-1]
+    
+    def get_tiles(self) -> List[Tile]:
+        """
+        Pull out the tiles contained within the Path object.
+
+        Copies on access so that accessors don't inadvertently reach back in 
+        / around the lock and mutate the internal list.
+        """
+        with self._lock:
+            return copy.copy(self._tiles)  # shallow-copy so that we don't accidentally list mumble mutate
+
+    def __getitem__(self, key: Union[int, slice]) -> Union[Tile, List[Tile]]:
+        """
+        Support integer index and slice access.
+
+        For example, you can say:
+
+        >>> path = Path((0,0), (0,1), (1,1), (1,2))
+        >>> path[1]  # access by index
+        (0, 1)
+        >>> path[0:2]  # slice
+        ((0, 0), (0, 1), (1, 1))
+
+        This is low-key partly for backward compatibility, because
+        I'm dropping this in to replace a `Path = List[Tile]` type alias.
+
+        Raises an IndexError if the index/slice is out of bounds.
+
+        Copies on access so that accessors don't inadvertently reach back in 
+        / around the lock and mutate the internal list.
+        """
+        with self._lock:
+            return copy.copy(self._tiles[key])
+
+    def __str__(self) -> str:
+        # I keep trying to print(self) during critical sections in which
+        # I already have the lock held, so I'm not going to access it here.
+        # That exposes us to edge cases in which self._tiles gets mutated while
+        # we're translating it to str, in which case............ idk! We'll
+        # figure it out!
+        return f"Path: {self._tiles}"

--- a/pi_controller/pi_controller/pathplanner.py
+++ b/pi_controller/pi_controller/pathplanner.py
@@ -10,56 +10,56 @@ import numpy as np
 import random
 from queue import PriorityQueue
 
-from .constants import Node, Path
-from .custommap import load_from_file, node_is_passable, add_obstacle, Node
+from .constants import Tile, Path
+from .custommap import load_from_file, tile_is_passable, add_obstacle, Tile
 
 class PathFinder:
     def __init__(self, map_file: str):
         self.grid = load_from_file(map_file)
         self.map_width, self.map_height = self.grid.shape
 
-    def redraw_path(self, start: Node, cat_location: Node) -> Path:
+    def redraw_path(self, start: Tile, cat_location: Tile) -> Path:
         retries = 100
         path = None
         self.grid = add_obstacle(self.grid, cat_location, 2, 2)
         for i in range(retries):
-            goal = self._get_random_passable_node()
+            goal = self._get_random_passable_tile()
             path = self.go_to_coords(start, goal)
             if path: return path
         print("ERROR: Unable to generate a new path after 100 retries")
 
     def redraw_path_if_necessary(
         self, 
-        start: Node, 
-        cat_location: Node, 
-        path: List[Node], 
+        start: Tile, 
+        cat_location: Tile, 
+        path: List[Tile], 
         cat_closeness_threshhold: Optional[int],
-        check_upcoming_nodes: Optional[int],
+        check_upcoming_tiles: Optional[int],
         minimum_path_len: Optional[int]
     ) -> Path:
         if len(path) < minimum_path_len:
             return self.redraw_path(start, cat_location)
-        for node in path[:check_upcoming_nodes]:
-            dx_too_small = abs(node[0] - cat_location[0]) <= cat_closeness_threshhold
-            dy_too_small = abs(node[1] - cat_location[1]) <= cat_closeness_threshhold
+        for tile in path[:check_upcoming_tiles]:
+            dx_too_small = abs(tile[0] - cat_location[0]) <= cat_closeness_threshhold
+            dy_too_small = abs(tile[1] - cat_location[1]) <= cat_closeness_threshhold
             cat_is_close = dx_too_small or dy_too_small 
             if cat_is_close:
                 return self.redraw_path(start, cat_location)
 
-    def go_to_coords(self, start: Node, goal: Node) -> Optional[Path]:
+    def go_to_coords(self, start: Tile, goal: Tile) -> Optional[Path]:
         return self._a_star(start, goal)
 
-    def _get_neighbors(self, node: Node) -> List[Node]:
+    def _get_neighbors(self, tile: Tile) -> List[Tile]:
         directions = [(-1, 0), (1, 0), (0, -1), (0, 1)]
         return [
-            (node[0] + dx, node[1] + dy)
+            (tile[0] + dx, tile[1] + dy)
             for dx, dy in directions
-            if 0 <= node[0] + dx < self.map_width
-            and 0 <= node[1] + dy < self.map_height
-            and node_is_passable(self.grid[node[0] + dx, node[1] + dy])
+            if 0 <= tile[0] + dx < self.map_width
+            and 0 <= tile[1] + dy < self.map_height
+            and tile_is_passable(self.grid[tile[0] + dx, tile[1] + dy])
         ]
 
-    def _a_star(self, start: Node, goal: Node) -> Optional[Path]:
+    def _a_star(self, start: Tile, goal: Tile) -> Optional[Path]:
         open_set = PriorityQueue()
         open_set.put((0, start))
         came_from = {}
@@ -83,10 +83,10 @@ class PathFinder:
 
         return None
 
-    def _heuristic(self, node: Node, goal: Node) -> int:
-        return abs(node[0] - goal[0]) + abs(node[1] - goal[1])
+    def _heuristic(self, tile: Tile, goal: Tile) -> int:
+        return abs(tile[0] - goal[0]) + abs(tile[1] - goal[1])
 
-    def _reconstruct_path(self, came_from: Dict[Node, Node], current: Node) -> Path:
+    def _reconstruct_path(self, came_from: Dict[Tile, Tile], current: Tile) -> Path:
         path = []
         while current in came_from:
             path.append(current)
@@ -94,11 +94,11 @@ class PathFinder:
         path.append(current)
         return path[::-1]
 
-    def _get_random_passable_node(self) -> Node:
+    def _get_random_passable_tile(self) -> Tile:
         while True:
-            node = (random.randint(0, self.map_width - 1), random.randint(0, self.map_height - 1))
-            if self.grid[node] == 0:
-                return node
+            tile = (random.randint(0, self.map_width - 1), random.randint(0, self.map_height - 1))
+            if self.grid[tile] == 0:
+                return tile
 
 if __name__ == '__main__':
     path_finder = PathFinder('map.csv')


### PR DESCRIPTION
The map is a grid, yes? and we've been conceptualizing it as an undirected graph of nodes (points) connected by regular edges (four per internal node -- left, right, up, down).

However as we start to glue together the map and the motion system this is feeling weird, like I'm associating physical points on the board with the nearest node, and what I really want is to have the map be of a series of squares each of which has actual area.

So I've found myself translating "node" to "tile" in my comments and documentation and brain, which feels a lot more intuitive.

"Is this point contained within this tile?" --> yes! so intuitive. Easy to reason about. "Is this point associated to this node?" is just not so.

So hoping to rip off the bandaid now while we're fast and light, do one fell swoop refactor and move on with our lives :)